### PR TITLE
Criar arquivo .gitignore na raiz do repositorio e manter a pasta data…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/


### PR DESCRIPTION
Como o git não mantém diretórios, ao retirar o sqlite do versionamento, ao fazer o clone o git não recriava a pasta database, impedindo o migrate e o seed. Por isso foi adicionado o arquivo .kitKeep

também adicionei um .gitignore com os arquivos do vscode para permitir padronizações locais a depender do ambiente de cada um.