### PR TITLE
Correção do campo duplicado

### DIFF
--- a/backend/src/models/notificacao.js
+++ b/backend/src/models/notificacao.js
@@ -21,9 +21,6 @@ module.exports = (sequelize, DataTypes) => {
     Notificacao.belongsTo(models.ProfissionalSaude, {
       foreignKey: "notificadorId",
     });
-    Notificacao.belongsTo(models.ProfissionalSaude, {
-      foreignKey: "notificadorId",
-    });
     Notificacao.belongsTo(models.Bairro, {
       foreignKey: "bairroId",
     });

--- a/backend/src/models/notificacaohistorico.js
+++ b/backend/src/models/notificacaohistorico.js
@@ -61,7 +61,7 @@ module.exports = (sequelize, DataTypes) => {
     observacoes: DataTypes.TEXT,
   }, {});
   NotificacaoHistorico.associate = function (models) {
-    NotificacaoHistorico.belongsTo(models.Notificacao);
+    NotificacaoHistorico.belongsTo(models.Notificacao, { foreignKey: 'notificacaoId'});
   };
   return NotificacaoHistorico;
 };


### PR DESCRIPTION
Após salvar a pessoa, notificação e notificação histórico é feito uma consulta recuperando a notificação por id, que retornava um campo que não existe