### PR TITLE
Bugfix/corrigir migrations

### DIFF
--- a/backend/src/db/migrations/20200416184430-adicionando-campos-pessoa.js
+++ b/backend/src/db/migrations/20200416184430-adicionando-campos-pessoa.js
@@ -1,15 +1,25 @@
 
 module.exports = {
-  up: (queryInterface, Sequelize) => Promise.all([
-    queryInterface.addColumn('Pessoa', 'gestante', {
-      type: Sequelize.STRING(12),
-    }),
-    queryInterface.addColumn('Pessoa', 'racaCor', {
-      type: Sequelize.STRING(10),
-    }),
-  ]),
-  down: (queryInterface) => Promise.all([
-    queryInterface.removeColumn('Pessoa', 'gestante'),
-    queryInterface.removeColumn('Pessoa', 'racaCor'),
-  ]),
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.addColumn('Pessoa', 'gestante', { type: Sequelize.STRING(12) }, { transaction });
+      await queryInterface.addColumn('Pessoa', 'racaCor', { type: Sequelize.STRING(10) }, { transaction });
+      await transaction.commit();
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
+  },
+  async down(queryInterface) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.removeColumn('Pessoa', 'gestante', { transaction });
+      await queryInterface.removeColumn('Pessoa', 'racaCor', { transaction });
+      await transaction.commit();
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
+  },
 };

--- a/backend/src/db/migrations/20200416210821-adicionando-campos-notificacaocovid19.js
+++ b/backend/src/db/migrations/20200416210821-adicionando-campos-notificacaocovid19.js
@@ -108,44 +108,51 @@ module.exports = {
     }),
   ]),
 
-  down: (queryInterface, Sequelize) => Promise.all([
-    queryInterface.removeColumn('NotificacaoCovid19', 'congestaoNasal'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'tiragemIntercostal'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'adiamiaFraqueza'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'artralgia'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'calafrios'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'conjuntivite'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'dificuldadeDeglutir'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'gangliosLinfaticos'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'irritabilidadeConfusao'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'manchasVermelhar'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'tabagismo'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'hipertensao'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'infeccaoHIV'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'neoplasia'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'diminuicaoDePulsoPeriferico'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'realizouExameDeImagem'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'raioXNormal'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'raioXInfiltrado'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'raioxXConsolidacao'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'raioXMisto'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'raioXOutro'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'tomografiaNormal'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'tomografiaVitro'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'tomografiaDerrame'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'tomografiaLinfonodo'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'tomografiaOutro'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'dataDaColeta'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'metodoDeExame'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'contatoComSuspeito'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'localDoContatoComSuspeito'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'localDoContatoComSuspeitoOutro'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'nomeSuspeito'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'situacaoNoMomentoDaNotificacao'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'feberAferidaReferida'),
-    queryInterface.removeColumn('NotificacaoCovid19', 'temperaturaFebre'),
-    queryInterface.changeColumn('NotificacaoCovid19', 'recebeuVacinaDaGripeNosUltimosDozeMeses', {
-      type: Sequelize.BOOLEAN,
-    }),
-  ]),
+  async down(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.removeColumn('NotificacaoCovid19', 'congestaoNasal', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'tiragemIntercostal', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'adiamiaFraqueza', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'artralgia', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'calafrios', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'conjuntivite', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'dificuldadeDeglutir', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'gangliosLinfaticos', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'irritabilidadeConfusao', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'manchasVermelhar', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'tabagismo', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'hipertensao', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'infeccaoHIV', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'neoplasia', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'diminuicaoDePulsoPeriferico', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'realizouExameDeImagem', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'raioXNormal', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'raioXInfiltrado', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'raioxXConsolidacao', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'raioXMisto', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'raioXOutro', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'tomografiaNormal', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'tomografiaVitro', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'tomografiaDerrame', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'tomografiaLinfonodo', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'tomografiaOutro', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'dataDaColeta', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'metodoDeExame', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'contatoComSuspeito', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'localDoContatoComSuspeito', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'localDoContatoComSuspeitoOutro', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'nomeSuspeito', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'situacaoNoMomentoDaNotificacao', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'feberAferidaReferida', { transaction });
+      await queryInterface.removeColumn('NotificacaoCovid19', 'temperaturaFebre', { transaction });
+      await queryInterface.changeColumn('NotificacaoCovid19', 'recebeuVacinaDaGripeNosUltimosDozeMeses', {
+        type: Sequelize.BOOLEAN,
+      }, { transaction });
+      await transaction.commit();
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
+  },
 };

--- a/backend/src/db/migrations/20200417214428-adicionando-status-nomenotificador-notificacao.js
+++ b/backend/src/db/migrations/20200417214428-adicionando-status-nomenotificador-notificacao.js
@@ -1,17 +1,24 @@
 
 module.exports = {
-  up: (queryInterface, Sequelize) => Promise.all([
+  up: (queryInterface, Sequelize) => queryInterface.sequelize.transaction((t) => Promise.all([
     queryInterface.addColumn('Notificacao', 'nomeNotificador', {
       type: Sequelize.STRING,
-    }),
+    }, { transaction: t }),
     queryInterface.addColumn('Notificacao', 'status', {
       type: Sequelize.STRING(9),
       allowNull: false,
       defaultValue: 'ABERTA',
-    }),
-  ]),
-  down: (queryInterface) => Promise.all([
-    queryInterface.removeColum('Notificacao', 'nomeNotificador'),
-    queryInterface.removeColum('Notificacao', 'status'),
-  ]),
+    }, { transaction: t }),
+  ])),
+  async down(queryInterface) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.removeColumn('Notificacao', 'nomeNotificador', { transaction });
+      await queryInterface.removeColumn('Notificacao', 'status', { transaction });
+      await transaction.commit();
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
+  },
 };

--- a/backend/src/db/migrations/20200417221338-adiciona-status-notificacao.js
+++ b/backend/src/db/migrations/20200417221338-adiciona-status-notificacao.js
@@ -1,7 +1,10 @@
 module.exports = {
-  up: (queryInterface, Sequelize) => queryInterface.addColumn('Notificacao', 'status', {
+  up: (queryInterface, Sequelize) => queryInterface.changeColumn('Notificacao', 'status', {
     type: Sequelize.STRING(18),
     defaultValue: 'ABERTO',
   }),
-  down: (queryInterface) => queryInterface.removeColumn('Notificacao', 'status'),
+  down: (queryInterface, Sequelize) => queryInterface.changeColumn('Notificacao', 'status', {
+    type: Sequelize.STRING(9),
+    defaultValue: 'ABERTA',
+  }),
 };


### PR DESCRIPTION
o comando "Down" não está aceitando o retorno "Promise.All([...]), quebrando a operação "Undo" das migrations.
Seria aconselhável utilizar transactions para operações que alteram mais de um campo.

https://sequelize.org/master/manual/migrations.html#migration-skeleton

Dois devs fizeram a mesma alteração no banco, tipificando a repetição de tarefas.