### PR TITLE
fix #288 Campo Descrição da ocupação estará sempre ativo

### DIFF
--- a/frontend/src/components/Notificacao/Form/IdentificacaoCaso/Ocupacao.vue
+++ b/frontend/src/components/Notificacao/Form/IdentificacaoCaso/Ocupacao.vue
@@ -16,7 +16,6 @@
         :value="suspeito.ocupacao"
         label="Descrição da ocupação"
         @input="updateDescricaoOcupacao"
-        :disabled="isOcupacaoDisable"
       />
     </v-col>
   </v-row>
@@ -37,7 +36,6 @@ export default {
   },
   data: () => ({
     ocupacoes: [],
-    isOcupacaoDisable: true,
     rules: {
       ocupacaoId: [required],
     },
@@ -47,7 +45,6 @@ export default {
       this.$emit('update:updateDescricaoOcupacao', descricaoOcupacao);
     },
     updateOcupacao(ocupacao) {
-      this.validateOcupacaoDisabled(ocupacao);
       this.$emit('update:ocupacao', ocupacao);
     },
     findOcupacoes() {
@@ -55,14 +52,6 @@ export default {
         .then(({ data }) => {
           this.ocupacoes = data;
         });
-    },
-    validateOcupacaoDisabled(ocupacao) {
-      const validateOcupacao = this.ocupacoes.find((ocupacaoFilter) => ocupacaoFilter.id === ocupacao);
-      if (validateOcupacao && validateOcupacao.descricao === 'Outro') {
-        this.isOcupacaoDisable = false;
-      } else {
-        this.isOcupacaoDisable = true;
-      }
     },
   },
   created() {


### PR DESCRIPTION
### Qualquer submissão:
Você está subindo o código de uma Issue?
* [x] Você vinculou sua issue ao PR?
Se você não está subindo código de uma issue:
* [x] Você chegou a criar a issue antes de fazer o PR?

* [x] Verificou se não há outro [Pull Requests](../../../pulls) aberto para a mesma alteração?
* [x] Vinculou este PR a uma Issue ([ou está seguindo os padrões para fechamento automático](https://help.github.com/pt/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))?

1. [x] Sua submissão passou nos testes?
2. [x] Seu código está de acordo com o lint do projeto?
3. [ ] Ainda é possível fazer/desfazer todos os migrates e seeds?
4. [ ] Você criou novos testes para o código escrito?
5. [ ] Os testes foram rodados e passaram localmente?

* [x] Como fazer o checkbox ficar marcado?
